### PR TITLE
Add show your work page for lightning talks

### DIFF
--- a/show-your-work.html
+++ b/show-your-work.html
@@ -33,4 +33,8 @@ title: Show Your Work | CTFEDs
         <h2>Get in touch!</h2>
 
         <p>Ready to lightning talk? <a href="https://www.meetup.com/ctfeds/members/?op=leaders">Let us know!</a></p>
+
+        <hr />
+
+        <p>Our turn for credit where it's due: the name of this and the push to get it going (again) came from reading <a href="https://twitter.com/austinkleon">Austin Kleon</a>'s book <a href="https://austinkleon.com/show-your-work/">Show Your Work</a>. :)</p>
   </article>

--- a/show-your-work.html
+++ b/show-your-work.html
@@ -1,0 +1,34 @@
+---
+layout: home
+title: Show Your Work | CTFEDs
+---
+
+    <article class="article">
+        <h1 class="block-header">Show Your Work</h1>
+
+        <p>What are you working on? What's something interesting you've just learned? We want to hear from you. Yes, <em>you!</em> If it's something on <a href="/call-for-speakers/#topics-and-timing">our talk wishlist</a>, even better! \o/</p>
+
+        <p>You don't have to give a long talk or run a workshop to share your knowledge and help other people learn something. A little lightning talk will do! Here's a handy template to <strong>Show Your Work</strong> to friends, family, and some <a href="https://www.meetup.com/ctfeds/members/">Cape Town Front-end Developers</a>. :)</p>
+
+        <h2>1: Elevator Pitch</h2>
+
+        <p><strong>In one sentence, say why this is interesting.</strong> What's the takeaway for people listening? What problem does it solve, or what thing can they learn?</p>
+
+        <p>If you can't say it in one sentence, stop and think for a moment. Are you trying to cover too much? Just cover one thing, or one piece of a big thing, in some detail. Are you not sure what to say? Tell us about how it saved you time, make something easier, or was something new to you.</p>
+
+        <h2>2: Short demo</h2>
+
+        <p><strong>Show us this thing in action.</strong></p>
+
+        <p>You don't have to do live coding: that can be quite nerve-wracking, and things can sometimes go a bit wrong (just like in day-to-day life!). Show us the finished thing and show us the source code. Think about how a Front-end style guide <a href="https://getbootstrap.com/docs/4.0/components/alerts/#examples">like Twitter Bootstrap does this with their alerts</a>: explanation, example, code sample.</p>
+
+        <h2>3: Credit where it's due</h2>
+
+        <p><strong>Tell us how and where you found out about this.</strong></p>
+
+        <p>One of the best things about our industry is the amount and awesomeness of the resources available. Did you find out about this thing on <a href="https://www.smashingmagazine.com/">Smashing Mag</a>, or <a href="https://css-tricks.com/">CSS Tricks</a>? On Twitter from <a href="https://twitter.com/anna_debenham">Anna Debenham</a> or <a href="https://twitter.com/SaraSoueidan">Sara Soueidan</a>? Let us know so we can find more cool stuff too.</p>
+
+        <h2>Get in touch!</h2>
+
+        <p>Ready to lightning talk? <a href="https://www.meetup.com/ctfeds/members/?op=leaders">Let us know!</a></p>
+  </article>

--- a/show-your-work.html
+++ b/show-your-work.html
@@ -8,7 +8,9 @@ title: Show Your Work | CTFEDs
 
         <p>What are you working on? What's something interesting you've just learned? We want to hear from you. Yes, <em>you!</em> If it's something on <a href="/call-for-speakers/#topics-and-timing">our talk wishlist</a>, even better! \o/</p>
 
-        <p>You don't have to give a long talk or run a workshop to share your knowledge and help other people learn something. A little lightning talk will do! Here's a handy template to <strong>Show Your Work</strong> to friends, family, and some <a href="https://www.meetup.com/ctfeds/members/">Cape Town Front-end Developers</a>. :)</p>
+        <p>You don't have to give a long talk or run a workshop to share your knowledge and help other people learn something. A little lightning talk will do! The talk should be about 5 minutes long.</p>
+
+        <p>Here's a handy template to <strong>Show Your Work</strong> to friends, family, and some <a href="https://www.meetup.com/ctfeds/members/">Cape Town Front-end Developers</a>. :)</p>
 
         <h2>1: Elevator Pitch</h2>
 


### PR DESCRIPTION
@justinslack @slinky-bass: I was thinking about trying a lightning talk meetup again. This PR adds a page to help people with that. Rather than just saying "do a lightning talk," we could provide a little help in terms of structure.

What do you think?